### PR TITLE
Fixed syntax error of the index.pug template

### DIFF
--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -3,7 +3,7 @@ extends layout
 block content
   h1= title
   p Welcome to #{title}
-  h1= GitHub Actions Deployment Pipeline
+  h1 GitHub Actions Deployment Pipeline
   p Testing GitHub Actions pipeline!
   p Push again to see if changes made can be seen here!
   


### PR DESCRIPTION
- Deleted `=` from `h1= GitHub Actions Deployment Pipeline`.
- The content to be rendered here is actually static, there's no need to use `=`.