### PR TITLE
Manually truncate message longer than 500 characters

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -35,11 +35,29 @@ async function expandCommitMessage(commitMessage) {
 
 };
 
+// Function to truncate the message to limit the message length
+function truncateMessageFromEnd(message, maxLength) {
+  if (message.length <= maxLength){
+    return message;
+  }
+
+  let words = message.split(' ');
+
+  while(message.length > maxLength) {
+    words.pop();
+    message = words.join(' ');
+  }
+
+  return message;
+};
+
 // Function to make a post on Mastodon
 async function postToMastodon(messageToPost) {
   try {
+    // Truncate the message if it's longer than 500 characters
+    const truncatedMessage = truncateMessageFromEnd(messageToPost);
     const status = await masto.v1.statuses.create({
-      status: messageToPost
+      status: truncatedMessage
     });
 
     console.log('Maston post has been posted, the URL to the post is: ', status.url);


### PR DESCRIPTION
Even though I've set up the prompt to include the length limit of the post, ChatGPT can still generate posts longer than expected, so I added a function to truncate the generated post to limit its length, otherwise, the post won't be accepted by the platform.

But my implementation did't directly truncate the whole post character by character and make its length under 500, instead, I truncated the post word by word to avoid a single word being truncated in half and still maintain the clarity of the post.