### PR TITLE
Checked the doc and added the exact length limit

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -55,7 +55,7 @@ function truncateMessageFromEnd(message, maxLength) {
 async function postToMastodon(messageToPost) {
   try {
     // Truncate the message if it's longer than 500 characters
-    const truncatedMessage = truncateMessageFromEnd(messageToPost);
+    const truncatedMessage = truncateMessageFromEnd(messageToPost, 500);
     const status = await masto.v1.statuses.create({
       status: truncatedMessage
     });


### PR DESCRIPTION
I'm so sorry about this, since I totally forgot to specify the length limit in the function.

Now I've added the length limit, the function should work fine and posts longer than the expected length will be truncated. That's to say, even if ChatGPT generates longer posts after telling it not to, the post will still be accepted and posted on the platform.