### PR TITLE
Updated .gitignore to ignore pm2 config file ecosystem.config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ ehthumbs.db
 # Temporary files
 tmp/
 temp/
+
+# pm2 config files
+ecosystem.config.js

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -115,3 +115,6 @@ ehthumbs.db
 # Temporary files
 tmp/
 temp/
+
+# pm2 config files
+ecosystem.config.js


### PR DESCRIPTION
I set up the `ecosystem.config.js` file in order to set `NODE_ENV` and load the `.env` file, where I store credentials of the project, so that's why I excluded it from version control.