### PR TITLE
Reduced time complexity of truncateMessageFromEnd() from O(nk) to O(n)

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -36,19 +36,27 @@ async function expandCommitMessage(commitMessage) {
 };
 
 // Function to truncate the message to limit the message length
+// Although I've set the limit in the ChatGPT prompt, the generated posts sometimes still exceed the length limit
 function truncateMessageFromEnd(message, maxLength) {
   if (message.length <= maxLength){
     return message;
   }
 
+  // I truncate the message string word by word instead of character by character,
+  // so here I wrap all the words in the message string into an array
   let words = message.split(' ');
+  let difference = message.length - maxLength;
 
-  while(message.length > maxLength) {
-    words.pop();
-    message = words.join(' ');
+  while(difference > 0 && words.length > 0) {
+    // Get the last word of the array and pop it from the array
+    let lastWord = words.pop();
+    
+    // Subtract the length of the word plus one for the sapace between two words
+    difference -= (lastWord.length + 1);
   }
 
-  return message;
+  // Join the remaining words to form the truncated message
+  return words.join(' ');
 };
 
 // Function to make a post on Mastodon


### PR DESCRIPTION
The main purpose of the function `truncateMessageFromEnd()` is to limit the length of the post. Even though I've explicitly specify the length limit in the prompt, ChatGPT sometimes still generates posts longer than expected. To make the application more robust, I implemented the function `truncateMessageFromEnd()`.

However, the original implementation tries to rebuild the post string on each iteration, leading to a potentially high number of costly `join(' ')` operations. Now the `join(' ')` operation is performed only once after the appropriate number of words have been removed. Thus the overall time complexity becomes closer to `O(n)`, where n is the length of the input post, primarily due to the initial `split(' ')` operation and the final `join(' ')`.