### PR TITLE
Redirect to the registration page once finished the GitHub Auth flow

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -45,6 +45,9 @@ router.get('/github/callback', async (req, res) => {
         const githubUsername = githubResponse.data.login;
         console.log(githubResponse.data);
         console.log(githubUsername);
+
+        // Redirect to the registration page with the GitHub username
+        res.redirect(`/users/register?githubUsername=${githubUsername}`);
     } catch (error) {
         console.error('Error during gitHub authentication:', error);
         res.status(500).json({ message: 'Internal Server Error' });

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -13,7 +13,8 @@ router.get('/login', (req, res) => {
 });
 
 router.get('/register', (req, res) => {
-  res.render('register');
+  const { githubUsername } = req.query;
+  res.render('register', { githubUsername });
 });
 
 async function getUserRepositories(githubToken) {

--- a/server/views/register.pug
+++ b/server/views/register.pug
@@ -8,9 +8,15 @@ block content
         p.text-white-50.mb-5 Please finish the following authorizations!
 
         .d-flex.flex-column.align-items-center
-          button.btn.btn-outline-light.btn-lg.mb-3.w-100(type='button' onclick="window.location.href='/auth/github'")
-            i.fab.fa-github.fa-lg(style='margin-right: 8px')
-            | Authorize Github
+            if githubUsername
+                button.btn.btn-success.btn-lg.mb-3.w-100(type='button' disabled)
+                i.fab.fa-github.fa-lg(style='margin-right: 8px')
+                | GitHub Authorized
+            else
+                button.btn.btn-outline-light.btn-lg.mb-3.w-100(type='button' onclick="window.location.href='/auth/github'")
+                i.fab.fa-github.fa-lg(style='margin-right: 8px')
+                | Authorize GitHub
+          
           button.btn.btn-outline-light.btn-lg.w-100(type='button' onclick="window.location.href='/auth/linkedin'")
             i.fab.fa-linkedin.fa-lg(style='margin-right: 8px') 
             | Authorize LinkedIn


### PR DESCRIPTION
- Added a redirect route in the GitHub callback function to redirect the user back to the registration page once the user complets the GitHub Authorization flow.
- Updated the registration page to disable `Authorize Github` button once the user finishes the GitHub Authorization flow to avoid duplicate operations.