### PR TITLE
Updated the page layout of the registration page

### DIFF
--- a/server/views/register.pug
+++ b/server/views/register.pug
@@ -12,14 +12,16 @@ block content
             button.btn.btn-success.btn-lg.mb-3.w-100(type='button' disabled)
               i.fab.fa-github.fa-lg(style='margin-right: 8px')
               | GitHub Authorized
+
+            button.btn.btn-outline-light.btn-lg.w-100(type='button' onclick="window.location.href='/auth/linkedin'")
+              i.fab.fa-linkedin.fa-lg(style='margin-right: 8px') 
+              | Authorize LinkedIn
           else
             button.btn.btn-outline-light.btn-lg.w-100(type='button' onclick="window.location.href='/auth/github'")
               i.fab.fa-github.fa-lg(style='margin-right: 8px')
               | Authorize GitHub
           
-          button.btn.btn-outline-light.btn-lg.w-100(type='button' onclick="window.location.href='/auth/linkedin'")
-            i.fab.fa-linkedin.fa-lg(style='margin-right: 8px') 
-            | Authorize LinkedIn
+
 
         p.mt-3
           | If you've already done the authorization, 


### PR DESCRIPTION
In order to register an account, users need to authorize both GitHub and LinkedIn. To make the application more robust, users will be asked to authorize those services in a constant manner, which is to authorize GitHub first, then LinkedIn.