### PR TITLE
Implemented LinkedIn OAuth flow

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -9,6 +9,10 @@ const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
 const GITHUB_AUTH_CALLBACK_URL = process.env.GITHUB_AUTH_CALLBACK_URL;
 
+const LINKEDIN_CLIENT_ID = process.env.LINKEDIN_CLIENT_ID;
+const LINKEDIN_CLIENT_SECRET = process.env.LINKEDIN_CLIENT_SECRET;
+const LINKEDIN_CALLBACK_URL = process.env.LINKEDIN_CALLBACK_URL;
+
 // Redirect the user to GitHub's OAuth authorization page
 router.get('/github', (req, res) => {
     const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${GITHUB_CLIENT_ID}&redirect_uri=${GITHUB_AUTH_CALLBACK_URL}&scope=repo`;
@@ -60,7 +64,61 @@ router.get('/github/callback', async (req, res) => {
     }
 });
 
+// Redirect the user to LinkedIn's OAuth page 
+router.get('/linkedin', (req, res) => {
+    // Need to add the scope w_member_social in order to make posts on behalf of the user
+    const linkedinAuthUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${LINKEDIN_CLIENT_ID}&redirect_uri=${encodeURIComponent(LINKEDIN_CALLBACK_URL)}&scope=liteprofile%20emailaddress%20w_member_social`;
 
+    res.redirect(linkedinAuthUrl);
+});
+
+// Handle the callback from LinkedIn and exchange the authorization code for an access token
+router.get('/linkedin/callback', async (req, res) => {
+    // Extract the temporary authorization code from LinkedIn
+    const { code } = req.query;
+
+    try {
+        // Exchange the authorization code for an access token
+        const tokenResponse = await axios.post('https://www.linkedin.com/oauth/v2/accessToken', querystring.stringify({
+            grant_type: 'authorization_code',
+            code,
+            client_id: LINKEDIN_CLIENT_ID,
+            client_secret: LINKEDIN_CLIENT_SECRET,
+            redirect_uri: LINKEDIN_CALLBACK_URL
+        }), {
+            headers: {
+                'Content-Type' : 'x-www-form-urlencoded',
+            }
+        });
+
+        // Extract the access token from the response data
+        const accessToken = tokenResponse.data.access_token; // Valid within 60 days
+
+        // Now we can use the access token to fetch the user's profile information
+        const profileResponse = await axios.get('https://api.linkedin.com/v2/me', {
+            headers: {
+                Authorization: `Bearer ${accessToken}`
+            }
+        });
+        const linkedinId = profileResponse.data.id;
+
+        // Retrieve the github credentials from session store and save all of them in local DB
+        const { githubUsername, githubAccessToken } = req.session;
+        await pool.query(
+            'INSERT INTO users (github_username, linkedin_id, github_token, linkedin_token) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE github_token = VALUES(github_token), linkedin_token = VALUES(linkedin_token)',
+            [githubUsername, linkedinId, githubAccessToken, accessToken]
+        );
+
+        // Redirect to the registration page with the GitHub username and LinkedIn id
+        res.redirect(`/users/register?githubUsername=${githubUsername}&linkedinId=${linkedinId}`);
+
+    } catch (error) {
+        console.error('Error during LinkedIn authentication:', error);
+        // If the authorization process failed, redirect the user back to the registration page with an error message
+        // Since the user has already done the GitHub authorization, we need to include the githubUsername here
+        res.redirect(`/users/register?githubUsername=${githubUsername}&error=linkedinAuthFailed`);
+    }
+});
 
 
 module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -13,8 +13,8 @@ router.get('/login', (req, res) => {
 });
 
 router.get('/register', (req, res) => {
-  const { githubUsername, error } = req.query;
-  res.render('register', { githubUsername, error });
+  const { githubUsername, linkedinId, error } = req.query;
+  res.render('register', { githubUsername, linkedinId, error });
 });
 
 async function getUserRepositories(githubToken) {

--- a/server/views/register.pug
+++ b/server/views/register.pug
@@ -11,15 +11,26 @@ block content
           if error == 'githubAuthFailed'
             p.text-danger.mb-1 GitHub authorization failed!
             p.text-danger.mb-3 Please try again!
+          else if error == 'linkedinAuthFailed'
+            p.text-danger.mb-1 LinkedIn authorization failed!
+            p.text-danger.mb-3 Please try again!
 
           if githubUsername
             button.btn.btn-success.btn-lg.mb-3.w-100(type='button' disabled)
               i.fab.fa-github.fa-lg(style='margin-right: 8px')
               | GitHub Authorized
 
-            button.btn.btn-outline-light.btn-lg.w-100(type='button' onclick="window.location.href='/auth/linkedin'")
-              i.fab.fa-linkedin.fa-lg(style='margin-right: 8px') 
-              | Authorize LinkedIn
+            if linkedinId
+              button.btn.btn-success.btn-lg.mb-3.w-100(type='button' disabled)
+                i.fab.fa-github.fa-lg(style='margin-right: 8px')
+                | LinkedIn Authorized
+              button.btn.btn-primary.btn-lg.w-100(type='button' onclick="window.location.href='/users/login'")
+                i.fas.fa-sign-in-alt.fa-lg(style='margin-right: 8px')
+                | Login Now
+            else 
+              button.btn.btn-outline-light.btn-lg.w-100(type='button' onclick="window.location.href='/auth/linkedin'")
+                i.fab.fa-linkedin.fa-lg(style='margin-right: 8px') 
+                | Authorize LinkedIn
           else
             button.btn.btn-outline-light.btn-lg.w-100(type='button' onclick="window.location.href='/auth/github'")
               i.fab.fa-github.fa-lg(style='margin-right: 8px')


### PR DESCRIPTION
- Implemented LinkedIn OAuth flow so that once the user finishes LinkedIn authorization, we can get the access token and make posts on behalf of the user, without the user manually setting up the access token.
- Persisted the user data(GitHub and LinkedIn credentials) in local MySQL database.
- Added an error message in `register.pug` when LinkedIn OAuth failed.
- Added a `Login Now` button in `register.pug` when both GitHub and LinkedIn OAuth succeed.