### PR TITLE
Fixed session store connection error

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -20,7 +20,7 @@ const port = process.env.PORT || 5000;
 
 // MySQL session store configuration
 const sessionStore = new MySQLStore({
-  host: process.env.DB_HOST,
+  host: '127.0.0.1',
   port: 3306,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const axios = require('axios');
 const router = express.Router();
+const querystring = require('querystring');
 require('dotenv').config();
 const pool = require('../db.js');  // Import the MySQL connection pool
 


### PR DESCRIPTION
- Changed the `host` field to `127.0.0.1` to use IPv4 address explicitly in the configuration of the session store, so that it won't resolve `localhost` to `::1`(IPv6), since the MySQL server is not configured to accept connections on `::1`.