### PR TITLE
Updated index.pug to properly display the user's github username

### DIFF
--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -5,4 +5,4 @@ block content
   p Welcome to #{title}
 
   if userInfo
-    p Welcome our GitHub guest: #{userInfo.github_username}
+    p Welcome our GitHub guest: #{userInfo[0].github_username}


### PR DESCRIPTION
- The `userInfo` stored in session store is actually an array instead of a single object, in order to fetch the GitHub username from it, I changed `#{userInfo.github_username}` to `#{userInfo[0].github_username}` from the `index.pug` file.