### PR TITLE
Replaced the 'type' parameter with 'affiliation'

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -47,7 +47,7 @@ async function fetchGitHubRepos(githubToken) {
       },
       params: {
         visibility: 'all', // to get both public and private repositories
-        type: 'owner' // to ensure that only repositories owned by the authenticated user are returned.
+        affiliation: 'owner' // to ensure that only repositories owned by the authenticated user are returned.
       }
     });
 


### PR DESCRIPTION
- Replaced the `type` parameter with `affiliation`, since we're not allowed to specify both `type` and `visibility` as required by GitHub.