### PR TITLE
Properly fetched linkedinId from database

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -240,14 +240,14 @@ async function postToMastodon(messageToPost) {
 }
 
 // Function to make a post on LinkedIn
-async function postToLinkedIn(message, accessToken) {
+async function postToLinkedIn(message, accessToken, linkedinId) {
   // Truncate the message if it's longer than 2000 characters
   const truncatedMessage = truncateMessageFromEnd(message, 1500);
 
   const url = 'https://api.linkedin.com/v2/ugcPosts';
   
   const payload = {
-    author: `urn:li:person:${req.session.user[0].linkedin_id}`,
+    author: `urn:li:person:${linkedinId}`,
     lifecycleState: 'PUBLISHED',
     specificContent: {
       'com.linkedin.ugc.ShareContent': {
@@ -297,9 +297,10 @@ router.post('/webhook', async (req, res) => {
       if (rows.length > 0){
         // Retrieve the linkedin-access-token 
         const linkedinAccessToken = rows[0].linkedin_token;
+        const linkedinId = rows[0].linkedin_id;
 
         // Post to LinkedIn on behalf of the user
-        const postResponse = await postToLinkedIn(expandedMessage, linkedinAccessToken);
+        const postResponse = await postToLinkedIn(expandedMessage, linkedinAccessToken, linkedinId);
         console.log('LinkedIn post response:', postResponse.data);
 
         // Send a success response to GitHub


### PR DESCRIPTION
- The route `/webhook` is triggered by GitHub, so this route has no access to the user's info stored in the session store so we need to retrieve the repo's owner login name along with the commit message.
- Next, we need to fetch the user's linkedinId using the github username from local db.